### PR TITLE
Remove temporary buffering when unmarshaling json

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -229,7 +229,7 @@ func (c *Client) NewAuthorization(accountKey interface{}, typ, val string) (auth
 	}
 	payload, err := c.signObject(accountKey, &data)
 	if err != nil {
-		return auth, "", nil
+		return auth, "", err
 	}
 	resp, err := c.client.Post(c.resources.NewAuthorization, jwsContentType, strings.NewReader(payload))
 	if err != nil {

--- a/nonce.go
+++ b/nonce.go
@@ -21,6 +21,9 @@ type nonceRoundTripper struct {
 }
 
 func newNonceRoundTripper(rt http.RoundTripper) *nonceRoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
 	return &nonceRoundTripper{rt: rt, mu: new(sync.Mutex)}
 }
 
@@ -40,11 +43,7 @@ func (nrt *nonceRoundTripper) Nonce() (string, error) {
 }
 
 func (nrt *nonceRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	if nrt.rt == nil {
-		resp, err = http.DefaultTransport.RoundTrip(req)
-	} else {
-		resp, err = nrt.rt.RoundTrip(req)
-	}
+	resp, err = nrt.rt.RoundTrip(req)
 	if err != nil {
 		return
 	}
@@ -59,5 +58,6 @@ func (nrt *nonceRoundTripper) RoundTrip(req *http.Request) (resp *http.Response,
 	if len(nrt.nonces) < 2048 {
 		nrt.nonces = append(nrt.nonces, tok)
 	}
+
 	return
 }


### PR DESCRIPTION
This pull request is primarily to remove temporary buffering when unmarshmaling json, but also included two other minor fixes. Here is the breakdown:

**Remove temporary buffering when unmarshmaling json**
Rather than buffering through ioutil.ReadAll, the library now uses json.NewDecoder so there is no need for temporary buffering.

**Fix bug where an error occurs but a nil error is returned**
In NewAuthorization, when signObject failed, the function was returning a nil err rather than the actual error. This change ensures the calling function is notified that an error occurred -- and what it was.

**Set http.DefaultTransport if one is not provided to newNonceRoundTripper**
This is a minor rework of what you had. Previously the nonceRoundTripper could have a nil rt (http.RoundTripper) and a check was done in the RoundTrip call. Now the check is moved up to the newNonceRoundTripper method so that RoundTrip can reliably call nrt.rt.Roundtrip without worrying about the underlying details.

Thanks for the great library!
