### PR TITLE
Package is un-go-gettable due to reference to old package name

### DIFF
--- a/Godeps/_workspace/src/github.com/square/go-jose/asymmetric.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/asymmetric.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ericchiang/acme/Godeps/_workspace/src/github.com/square/go-jose/cipher"
+	"github.com/ericchiang/letsencrypt/Godeps/_workspace/src/github.com/square/go-jose/cipher"
 )
 
 // A generic RSA-based encrypter/verifier

--- a/Godeps/_workspace/src/github.com/square/go-jose/jose-util/main.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/jose-util/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/ericchiang/acme/Godeps/_workspace/src/github.com/square/go-jose"
+	"github.com/ericchiang/letsencrypt/Godeps/_workspace/src/github.com/square/go-jose"
 )
 
 func main() {

--- a/Godeps/_workspace/src/github.com/square/go-jose/symmetric.go
+++ b/Godeps/_workspace/src/github.com/square/go-jose/symmetric.go
@@ -25,7 +25,7 @@ import (
 	"crypto/sha512"
 	"crypto/subtle"
 	"errors"
-	"github.com/ericchiang/acme/Godeps/_workspace/src/github.com/square/go-jose/cipher"
+	"github.com/ericchiang/letsencrypt/Godeps/_workspace/src/github.com/square/go-jose/cipher"
 	"hash"
 	"io"
 )


### PR DESCRIPTION
This fixes a reference to `acme` as the old project name in Godeps/ rather than the current `letsencrypt`.

Looks like you missed some of it in #3.
