### PR TITLE
Fix invalid memory address crash on invalid challenges

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -168,7 +168,7 @@ func (c *Client) ChallengeReady(accountKey interface{}, chal Challenge) error {
 		case StatusPending, "":
 			time.Sleep(pollInterval)
 		case StatusInvalid:
-			if err.Error == nil {
+			if chal.Error == nil {
 				return errors.New("challenge returned status 'invalid' without explicit error")
 			}
 			return chal.Error


### PR DESCRIPTION
When running ChallengeReady, if the challenge response from Acme is "invalid", a crash occurs. That is because the StatusInvalid case was trying to check err.Error (which is actually a function to return error as a string) for a nil value when it should have been checking chal.Error for a nil value.

This updates the variable name to the correct one to prevent crashes.
