### PR TITLE
Certificate Refactor: Certificate Response, Renewals, Async Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import (
     "github.com/ericchiang/letsencrypt"
 )
 
-var supportedChallengs = []string{
+var supportedChallenges = []string{
     letsencrypt.ChallengeHTTP,
     letsencrypt.ChallengeTLSSNI,
 }
@@ -72,11 +72,24 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-    // We've got a certificate. Let's Encrypt!
+
+    if cert.Certificate != nil {
+        // We've got a certificate. Let's Encrypt!
+
+        // cert.Certificate holds the x509 Certificate
+
+        // To bundle with the issuer certificate and get PEM encoded []byte:
+        bundledPEM, err := cert.Bundle()
+    }
+
+    // Need to try later. Wait n seconds as provided in cert.RetryAfter, then...
+    if err := cert.Retry(); err == nil {
+        // Certificate is now available in cert.Certificate
+    }
 }
 
 func newCSR() (*x509.CertificateRequest, *rsa.PrivateKey, error) {
-    certKey, err := rsa.GenerateKey(rand.Random, 4096)
+    certKey, err := rsa.GenerateKey(rand.Reader, 4096)
     if err != nil {
         return nil, nil, err
     }

--- a/acme.go
+++ b/acme.go
@@ -287,7 +287,7 @@ func (c *Client) Challenge(chalURI string) (Challenge, error) {
 // NewCertificate requests a certificate from the ACME server.
 //
 // csr must have already been signed by a private key.
-func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateRequest) (*Certificate, error) {
+func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateRequest) (*CertificateResponse, error) {
 	if csr == nil || csr.Raw == nil {
 		return nil, errors.New("invalid certificate request object")
 	}
@@ -340,8 +340,8 @@ func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateReq
 	links := parseLinks(resp.Header["Link"])
 	return &CertificateResponse{
 		Certificate: x509Cert,
-		URI:         resp.Header.get("Location"),
-		StableURI:   resp.Header.get("Content-Location"),
+		URI:         resp.Header.Get("Location"),
+		StableURI:   resp.Header.Get("Content-Location"),
 		Issuer:      links["up"],
 	}, nil
 }

--- a/certificate.go
+++ b/certificate.go
@@ -47,7 +47,12 @@ func (c *CertificateResponse) Bundle() (bundledPEM []byte, err error) {
 }
 
 // Retry request retries the certificate if it was unavailable when calling
-// NewCertificate.
+// NewCertificate or RenewCertificate.
+//
+// Note: If you are renewing a certificate, LetsEncrypt may return the same
+// certificate. You should load your current x509.Certificate and use the
+// Equal method to compare to the "new" certificate. If it's identical,
+// you'll need to start a new certificate flow.
 func (c *CertificateResponse) Retry() error {
 	if c.Certificate != nil {
 		return errors.New("Aborting retry request. Certificate is already available")

--- a/certificate.go
+++ b/certificate.go
@@ -22,7 +22,7 @@ type CertificateResponse struct {
 
 // Bundle bundles the certificate with the issuer certificate.
 func (c *CertificateResponse) Bundle() (bundledPEM []byte, err error) {
-	if c.Certificate == nil {
+	if !c.IsAvailable() {
 		return nil, errors.New("Cannot bundle without certificate")
 	}
 
@@ -55,7 +55,7 @@ func (c *CertificateResponse) Bundle() (bundledPEM []byte, err error) {
 // Equal method to compare to the "new" certificate. If it's identical,
 // you'll need to start a new certificate flow.
 func (c *CertificateResponse) Retry() error {
-	if c.Certificate != nil {
+	if c.IsAvailable() {
 		return errors.New("Aborting retry request. Certificate is already available")
 	}
 
@@ -128,11 +128,17 @@ func (c *CertificateResponse) RetryPoll(maxRetries int) error {
 		}
 
 		// Certificate was returned.
-		if c.Certificate != nil {
+		if c.IsAvailable() {
 			return nil
 		}
 
 		retries++
 		time.Sleep(time.Duration(c.RetryAfter) * time.Second)
 	}
+}
+
+// IsAvailable returns bool true if CertificateResponse has a certificate
+// available. It's a convenience function, but it helps with readability.
+func (c *CertificateResponse) IsAvailable() bool {
+	return c.Certificate != nil
 }

--- a/certificate.go
+++ b/certificate.go
@@ -1,0 +1,103 @@
+package letsencrypt
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+)
+
+// CertificateResponse holds response items after requesting a Certificate.
+type CertificateResponse struct {
+	Certificate *x509.Certificate
+	RetryAfter  int
+	URI         string
+	StableURI   string
+	Issuer      string
+}
+
+// Bundle bundles the certificate with the issuer certificate.
+func (c *CertificateResponse) Bundle() (bundledPEM []byte, err error) {
+	if c.Certificate == nil {
+		return errors.New("Cannot bundle without certificate")
+	}
+
+	if c.Issuer == "" {
+		return errors.New("Could not bundle certificates. Issuer not found")
+	}
+
+	resp, err := http.Get(c.Issuer)
+	if err != nil {
+		t.Errorf("Error requesting issuer certificate: %s", err)
+	}
+
+	defer resp.Body.Close()
+	issuerDER, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error reading issuer certificate: %s", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Certificate.Raw})
+	issuerPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: issuerDER})
+
+	return append(certPEM, issuerPEM...), nil
+}
+
+// Retry request retries the certificate if it was unavailable when calling
+// NewCertificate.
+func (c *CertificateResponse) Retry() error {
+	if c.Certificate != nil {
+		return errors.New("Aborting retry request. Certificate is already available")
+	}
+
+	if c.URI == "" {
+		return errors.New("Could not make retry request. No URI available")
+	}
+
+	resp, err := http.Get(c.URI)
+	if err != nil {
+		t.Errorf("Error retrying certificate request: %s", err)
+	}
+
+	defer resp.Body.Close()
+
+	// Certificate is available
+	if resp.statusCode == http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read response body: %s", err)
+		}
+
+		x509Cert, err := x509.ParseCertificate(body)
+		if err != nil {
+			return fmt.Errorf("Error parsing x509 certificate: %s", err)
+		}
+
+		c.Certificate = x509Cert
+		c.RetryAfter = 0
+
+		if stableURI := resp.Header.Get("Content-Location"); stableURI != "" {
+			c.StableURI = stableURI
+		}
+
+		links := parseLinks(resp.Header["Link"])
+		c.Issuer = links["up"]
+
+		return nil
+	}
+
+	// Certificate still isn't ready.
+	if resp.StatusCode == http.StatusAccepted {
+		retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+		if err != nil {
+			return fmt.Errorf("Error parsing retry-after header: %s", err)
+		}
+
+		c.RetryAfter = retryAfter
+
+		return nil
+	}
+}

--- a/challenge.go
+++ b/challenge.go
@@ -42,7 +42,7 @@ func (chal Challenge) HTTP(accountKey interface{}) (urlPath, resource string, er
 
 // TLSSNI returns TLS certificates for a set of server names.
 // The ACME server will make a TLS Server Name Indication handshake with the
-// given domain. The domain must present the returned certifiate for each name.
+// given domain. The domain must present the returned certificate for each name.
 func (chal Challenge) TLSSNI(accountKey interface{}) (map[string]*tls.Certificate, error) {
 	if chal.Type != "tls-sni-01" {
 		return nil, fmt.Errorf("challenge type is %s not %s", chal.Type, "tls-sni-01")

--- a/challenge.go
+++ b/challenge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ericchiang/letsencrypt/internal/base64"
 )
 
+// Challenge constants.
 const (
 	ChallengeDNS    = "dns-01"
 	ChallengeHTTP   = "http-01"
@@ -102,12 +103,12 @@ func (chal Challenge) TLSSNI(accountKey interface{}) (map[string]*tls.Certificat
 	return certs, nil
 }
 
-// Not yet implemented
+// DNS ... Not yet implemented
 func (chal Challenge) DNS(accountKey interface{}) (domain, txt string, err error) {
 	return "", "", errors.New("dns challenges not implemented")
 }
 
-// Not yet implemented
+// ProofOfPossession ... Not yet implemented
 func (chal Challenge) ProofOfPossession(accountKey, certKey interface{}) (Challenge, error) {
 	return Challenge{}, errors.New("proof of possession not implemented")
 }


### PR DESCRIPTION
This is a PR for the conversation started in issue #11. Unit tests are in progress pending review from @ericchiang.

Details:
- `NewCertificate` now returns `CertificateResponse` struct
- `NewCertificate` now supports asynchronous certificates (Not yet in Boulder, but based on spec)
- If `NewCertificate` call results in a synchronous certificate, `CertificateResponse.Certificate` is populated with `*x509.Certificate`. `URI` and `StableURI` are both set. The issuer url is set based on the rel="up" Link header. (see below for more details
- If `NewCertificate` call results in an empty response body, `CertificateResponse` is populated with `RetryAfter` and `URI`.
- `RenewCertificate` method
- `RevokeCertificate` method

Methods on `CertificateResponse`:
- `CertificateResponse` contains three methods: `Retry`, `RetryPoll`, and `Bundle`
- `Retry` will handle implementation details to retry the call to `CertificateResponse.URI`. User triggers it based on number of seconds passed in `CertificateResponse.RetryAfter`. Behavior here is the same as `NewCertificate` depending on if the certificate is available or requires another try.
- `RetryPoll` will poll retries `maxRetries` times
- `Bundle` allows for bundling the certificate with the cross-signed Issuer. This is a convenience method and puts the burden on the user to call, but the implementation details are covered in the library.
