### PR TITLE
Add CertificateResponse struct. New functions for Renew/Revoke/Retry/Bundle

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -287,7 +288,7 @@ func (c *Client) Challenge(chalURI string) (Challenge, error) {
 // NewCertificate requests a certificate from the ACME server.
 //
 // csr must have already been signed by a private key.
-func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateRequest) (*x509.Certificate, error) {
+func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateRequest) (*CertificateResponse, error) {
 	if csr == nil || csr.Raw == nil {
 		return nil, errors.New("invalid certificate request object")
 	}
@@ -311,11 +312,108 @@ func (c *Client) NewCertificate(accountKey interface{}, csr *x509.CertificateReq
 	if err := checkHTTPError(resp, http.StatusCreated); err != nil {
 		return nil, err
 	}
+
+	return handleCertificateResponse(resp)
+}
+
+// RenewCertificate attempts to renew an existing certificate.
+// Let's Encrypt may return the same certificate. You should load your
+// current x509.Certificate and use the Equal method to compare to the "new"
+// certificate. If it's identical, you'll need to run NewCertificate and/or
+// start a new certificate flow.
+func (c *Client) RenewCertificate(certURI string) (*CertificateResponse, error) {
+	resp, err := c.client.Get(certURI)
+	if err != nil {
+		return nil, fmt.Errorf("renew certificate http error: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return nil, errors.New("certificate not available. Start a new certificate flow")
+	}
+
+	certResp, err := handleCertificateResponse(resp)
+	if err == nil {
+		if certResp.URI == "" {
+			certResp.URI = certURI
+		}
+	}
+
+	return certResp, err
+}
+
+// RevokeCertificate takes a PEM encoded certificate or bundle and
+// attempts to revoke it.
+func (c *Client) RevokeCertificate(accountKey interface{}, pemBytes []byte) error {
+	certificates, err := parsePEMBundle(pemBytes)
+	if err != nil {
+		return err
+	}
+
+	cert := certificates[0]
+	if cert.IsCA {
+		return errors.New("Certificate bundle starts with a CA certificate")
+	}
+
+	// cert.Raw holds DERbytes, which need to be encoded to base64 per acme spec
+	encoded := base64.URLEncoding.EncodeToString(cert.Raw)
+	payload := struct {
+		Resource    string `json:"resource"`
+		Certificate string `json:"certificate"`
+	}{
+		resourceNewRevokeCertificate,
+		encoded,
+	}
+	data, err := c.signObject(accountKey, &payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Post(c.resources.NewRevokeCertificate, jwsContentType, strings.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := checkHTTPError(resp, http.StatusOK); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func handleCertificateResponse(resp *http.Response) (*CertificateResponse, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %v", err)
 	}
-	return x509.ParseCertificate(body)
+	defer resp.Body.Close()
+
+	// Certificate is not yet available. Gather data and retry later
+	if len(body) == 0 {
+		retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing retry-after header: %s", err)
+		}
+
+		return &CertificateResponse{
+			RetryAfter: retryAfter,
+			URI:        resp.Header.Get("Location"),
+		}, nil
+	}
+
+	// Certificate was available in response body
+	x509Cert, err := x509.ParseCertificate(body)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing x509 certificate: %s", err)
+	}
+
+	links := parseLinks(resp.Header["Link"])
+	return &CertificateResponse{
+		Certificate: x509Cert,
+		URI:         resp.Header.Get("Location"),
+		StableURI:   resp.Header.Get("Content-Location"),
+		Issuer:      links["up"],
+	}, nil
 }
 
 // TODO: doesn't need to be a function on the client struct
@@ -345,15 +443,51 @@ func (c *Client) signObject(accountKey interface{}, v interface{}) (string, erro
 	return sig.FullSerialize(), nil
 }
 
-var linkRegexp = regexp.MustCompile(`<([^>]+)>\s*;\s*rel\s*=\s*"([A-Za-z0-9\-_]+)"`)
+var aBrkt = regexp.MustCompile("[<>]")
+var slver = regexp.MustCompile("(.+) *= *\"(.+)\"")
 
-func parseLink(link string) (url, rel string, err error) {
-	match := linkRegexp.FindStringSubmatch(link)
-	if match == nil || len(match) != 3 {
-		err = fmt.Errorf("invalid link: %s", link)
-	} else {
-		url = match[1]
-		rel = match[2]
+func parseLinks(links []string) map[string]string {
+	linkMap := make(map[string]string)
+
+	for _, link := range links {
+		link = aBrkt.ReplaceAllString(link, "")
+		parts := strings.Split(link, ";")
+
+		matches := slver.FindStringSubmatch(parts[1])
+		if len(matches) > 0 {
+			linkMap[matches[2]] = parts[0]
+		}
 	}
-	return
+
+	return linkMap
+}
+
+// parsePEMBundle parses a certificate bundle from top to bottom and returns
+// a slice of x509 certificates. This function will error if no certificates are found.
+// Credit: github.com/xenolf/lego
+func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
+	var certificates []*x509.Certificate
+
+	remaining := bundle
+	for len(remaining) != 0 {
+		certBlock, rem := pem.Decode(remaining)
+		// Thanks golang for having me do this :[
+		remaining = rem
+		if certBlock == nil {
+			return nil, errors.New("Could not decode certificate.")
+		}
+
+		cert, err := x509.ParseCertificate(certBlock.Bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		certificates = append(certificates, cert)
+	}
+
+	if len(certificates) == 0 {
+		return nil, errors.New("No certificates were found while parsing the bundle.")
+	}
+
+	return certificates, nil
 }

--- a/acme_test.go
+++ b/acme_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -184,7 +186,7 @@ func TestNewCertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cert, err := cli.NewCertificate(priv, csr)
+	certResp, err := cli.NewCertificate(priv, csr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,46 +198,161 @@ func TestNewCertificate(t *testing.T) {
 		}
 		return false
 	}
-	if !contains(cert.DNSNames, testDomain) {
+	if !contains(certResp.Certificate.DNSNames, testDomain) {
 		t.Errorf("returned cert was not for test domain")
 	}
 
-	certPEM := pemEncode(cert.Raw, "CERTIFICATE")
+	certPEM := pemEncode(certResp.Certificate.Raw, "CERTIFICATE")
 	certKeyPEM := pemEncode(x509.MarshalPKCS1PrivateKey(certKey), "RSA PRIVATE KEY")
 	if _, err := tls.X509KeyPair(certPEM, certKeyPEM); err != nil {
 		t.Errorf("private key did not match returned cert")
 	}
+
+	if !certResp.IsAvailable() {
+		t.Error("Expected certificate to be available in CertificateResponse")
+	}
+
+	if certResp.Issuer == "" {
+		t.Error("Expected issuer to be non empty.")
+	}
+
+	pemBundle, err := cli.Bundle(certResp)
+	if err != nil {
+		t.Errorf("Expected bundling certificate to return no errors. Error: %s", err)
+	}
+
+	parsed, err := parsePEMBundle(pemBundle)
+	if err != nil {
+		t.Errorf("Expected parsePEMBundle to return no errors. Error: %s", err)
+	}
+
+	if len(parsed) != 2 {
+		t.Errorf("Expected bundled response to have two certificates. Given: %d", len(parsed))
+	}
+
+	if !reflect.DeepEqual(parsed[0].Raw, certResp.Certificate.Raw) {
+		t.Error("Expected first certificate in bundle to match original certificate")
+	}
+
+	if parsed[1].IsCA != true {
+		t.Error("Expected second certificate in bundle to be CA")
+	}
+
+	// Revoke
+	if err := cli.RevokeCertificate(priv, certPEM); err != nil {
+		t.Errorf("Revoke certificate failed. Error: %s", err)
+	}
 }
 
-func TestParseLink(t *testing.T) {
-	tests := []struct {
-		link string
-		ok   bool
-		url  string
-		rel  string
-	}{
-		{`<http://127.0.0.1:4000/acme/new-authz>;rel="next"`, true, "http://127.0.0.1:4000/acme/new-authz", "next"},
-		{`<http://127.0.0.1:4001/terms/v1>;rel="terms-of-service"`, true, "http://127.0.0.1:4001/terms/v1", "terms-of-service"},
-		{`<http://127.0.0.1:4001/terms/v1>; rel="terms-of-service"`, true, "http://127.0.0.1:4001/terms/v1", "terms-of-service"},
+func TestRenewCertificate(t *testing.T) {
+	cli, err := NewClient(testURL)
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, test := range tests {
-		url, rel, err := parseLink(test.link)
-		if err == nil && !test.ok {
-			t.Errorf("expected link to be bad: %s", test.link)
-			continue
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	block, _ := pem.Decode(pemCert)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Parsing pem certificate for test failed. Error: %s", err)
+	}
+
+	endpoint := server.URL + "/acme/cert/asdfouadfs"
+	mux.HandleFunc("/acme/cert/asdfouadfs", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("fail") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if err != nil && test.ok {
-			t.Errorf("could not parse link: %s", test.link)
-			continue
-		}
-		if err != nil {
-			continue
-		}
-		if test.url != url {
-			t.Errorf("expected link to produce url '%s' got '%s'", test.url, url)
-		}
-		if test.rel != rel {
-			t.Errorf("expected link to produce rel '%s' got '%s'", test.rel, rel)
+
+		w.Header().Set("Content-Type", "application/pkix-cert")
+		w.Header().Set("Link", fmt.Sprintf(`<%s>;rel="up"`, endpoint))
+		w.WriteHeader(http.StatusOK)
+		w.Write(x509Cert.Raw)
+	})
+
+	certResp, err := cli.RenewCertificate(endpoint)
+	if !certResp.IsAvailable() {
+		t.Error("Expected RenewCertificate would return a certificate")
+	}
+
+	if !reflect.DeepEqual(certResp.Certificate.Raw, x509Cert.Raw) {
+		t.Error("Expected RenewCertificate to return the same certificate")
+	}
+
+	if certResp.RetryAfter != 0 {
+		t.Errorf("Expected RetryAfter to equal %d, given %d", 0, certResp.RetryAfter)
+	}
+
+	if certResp.Issuer != endpoint {
+		t.Errorf("Expected issuer to equal %q, given %q", endpoint, certResp.Issuer)
+	}
+
+	// Test wrong status code returns an error
+	if _, err := cli.RenewCertificate(endpoint + "?fail=1"); err == nil {
+		t.Error("Expected invalid status code to return error")
+	}
+}
+
+func TestParseLinks(t *testing.T) {
+	tests := []struct {
+		header http.Header
+		want   map[string]string
+	}{
+		{
+			header: map[string][]string{
+				"Link": {
+					`<https://example.com/acme/new-authz>;rel="next"`,
+					`<https://example.com/acme/recover-reg>;rel="recover"`,
+					`<https://example.com/acme/terms>;rel="terms-of-service"`,
+				},
+			},
+			want: map[string]string{
+				"next":             "https://example.com/acme/new-authz",
+				"recover":          "https://example.com/acme/recover-reg",
+				"terms-of-service": "https://example.com/acme/terms",
+			},
+		},
+		{
+			header: map[string][]string{
+				"Link": []string{`<https://example.com/acme/new-cert>;rel="next"`},
+			},
+			want: map[string]string{
+				"next": "https://example.com/acme/new-cert",
+			},
+		},
+		{
+			header: map[string][]string{
+				"Link": {
+					`<https://example.com/acme/ca-cert>;rel="up";title="issuer"`,
+					`<https://example.com/acme/revoke-cert>;rel="revoke"`,
+					`<https://example.com/acme/reg/asdf>;rel="author"`,
+				},
+				"Location":         {"https://example.com/acme/cert/asdf"},
+				"Content-Location": {"https://example.com/acme/cert-seq/12345"},
+			},
+			want: map[string]string{
+				"up":     "https://example.com/acme/ca-cert",
+				"revoke": "https://example.com/acme/revoke-cert",
+				"author": "https://example.com/acme/reg/asdf",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		links := parseLinks(test.header["Link"])
+
+		for key, want := range test.want {
+			given, ok := links[key]
+			if !ok {
+				t.Errorf("TestParseLinks (%d): want rel of %q to be present", i, key)
+			}
+
+			if given != want {
+				t.Errorf("TestParseLinks (%d): want rel of %q to equal %s, given %s", i, key, want, given)
+			}
 		}
 	}
 }

--- a/certificate.go
+++ b/certificate.go
@@ -1,0 +1,116 @@
+package letsencrypt
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+)
+
+// CertificateResponse holds response items after requesting a Certificate.
+type CertificateResponse struct {
+	Certificate *x509.Certificate
+	RetryAfter  int
+	URI         string
+	StableURI   string
+	Issuer      string
+}
+
+// Bundle bundles the certificate with the issuer certificate.
+func (c *Client) Bundle(certResp *CertificateResponse) (bundledPEM []byte, err error) {
+	if !certResp.IsAvailable() {
+		return nil, errors.New("Cannot bundle without certificate")
+	}
+
+	if certResp.Issuer == "" {
+		return nil, errors.New("Could not bundle certificates. Issuer not found")
+	}
+
+	resp, err := c.client.Get(certResp.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("Error requesting issuer certificate: %s", err)
+	}
+	defer resp.Body.Close()
+
+	issuerDER, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading issuer certificate: %s", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certResp.Certificate.Raw})
+	issuerPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: issuerDER})
+
+	return append(certPEM, issuerPEM...), nil
+}
+
+// Retry request retries the certificate if it was unavailable when calling
+// NewCertificate or RenewCertificate.
+//
+// Note: If you are renewing a certificate, LetsEncrypt may return the same
+// certificate. You should load your current x509.Certificate and use the
+// Equal method to compare to the "new" certificate. If it's identical,
+// you'll need to request a new certificate using NewCertificate, or if your
+// chalenges have expired, start a new certificate flow entirely.
+func (c *Client) Retry(certResp *CertificateResponse) error {
+	if certResp.IsAvailable() {
+		return errors.New("Aborting retry request. Certificate is already available")
+	}
+
+	if certResp.URI == "" {
+		return errors.New("Could not make retry request. No URI available")
+	}
+
+	resp, err := c.client.Get(certResp.URI)
+	if err != nil {
+		return fmt.Errorf("Error retrying certificate request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	// Certificate is available
+	if resp.StatusCode == http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read response body: %s", err)
+		}
+
+		x509Cert, err := x509.ParseCertificate(body)
+		if err != nil {
+			return fmt.Errorf("Error parsing x509 certificate: %s", err)
+		}
+
+		certResp.Certificate = x509Cert
+		certResp.RetryAfter = 0
+
+		if stableURI := resp.Header.Get("Content-Location"); stableURI != "" {
+			certResp.StableURI = stableURI
+		}
+
+		links := parseLinks(resp.Header["Link"])
+		certResp.Issuer = links["up"]
+
+		return nil
+	}
+
+	// Certificate still isn't ready.
+	if resp.StatusCode == http.StatusAccepted {
+		retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+		if err != nil {
+			return fmt.Errorf("Error parsing retry-after header: %s", err)
+		}
+
+		certResp.RetryAfter = retryAfter
+
+		return nil
+	}
+
+	return fmt.Errorf("Retry expected status code of %d or %d, given %d", http.StatusOK, http.StatusAccepted, resp.StatusCode)
+}
+
+// IsAvailable returns bool true if CertificateResponse has a certificate
+// available. It's a convenience function, but it helps with readability.
+func (c *CertificateResponse) IsAvailable() bool {
+	return c.Certificate != nil
+}

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -1,0 +1,99 @@
+package letsencrypt
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+var pemCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIEVzCCAz+gAwIBAgITAP+xdyV4gP42OOW1GTK5/Dqh+zANBgkqhkiG9w0BAQsF
+ADAfMR0wGwYDVQQDExRoYXBweSBoYWNrZXIgZmFrZSBDQTAeFw0xNTEyMTQyMjM4
+MDBaFw0xNjAzMTMyMjM4MDBaMBYxFDASBgNVBAMTC2V4YW1wbGUub3JnMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyESSzaSOZeLoeVBABygcKMUuzKNR
+SgdmNWP7GsjgNFmj+eiz/nia+BNmtSuqHK47YBLyCzqiAmt3bJt55vjnYx8Hra2z
+W5TVwhpyzlOM0sbC0NzWOogDKC5woIEZGqdUTkaVEkIELQvNtOCjjjiIilk2A0K6
+WLdFFNQWqLSnTYGCo53Gh5RIZrIqQEUbgJ7MJemj6SuPuCyussrF+WtvaBb7xQjN
+LuVvprVv7NBuh8uz2cRuBLAsR03Fng1ItfuEtuLoKJC7Vfh2qBqwuEFZ8WoPP0H5
+HMXK8pLJ5I4jmpdLeOik75yfhmxcJjdT57SgApSlU5XidOXmmuUbuk/8vQIDAQAB
+o4IBkzCCAY8wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRMn3zVIo3wd1JgV+leFojm
+6JCgWzAfBgNVHSMEGDAWgBT7eE8S+WAVgyyfF380GbMuNupBiTBqBggrBgEFBQcB
+AQReMFwwJgYIKwYBBQUHMAGGGmh0dHA6Ly8xMjcuMC4wLjE6NDAwMi9vY3NwMDIG
+CCsGAQUFBzAChiZodHRwOi8vMTI3LjAuMC4xOjQwMDAvYWNtZS9pc3N1ZXItY2Vy
+dDAWBgNVHREEDzANggtleGFtcGxlLm9yZzAnBgNVHR8EIDAeMBygGqAYhhZodHRw
+Oi8vZXhhbXBsZS5jb20vY3JsMGMGA1UdIARcMFowCgYGZ4EMAQIBMAAwTAYDKgME
+MEUwIgYIKwYBBQUHAgEWFmh0dHA6Ly9leGFtcGxlLmNvbS9jcHMwHwYIKwYBBQUH
+AgIwEwwRRG8gV2hhdCBUaG91IFdpbHQwDQYJKoZIhvcNAQELBQADggEBAKOOjKpt
+xYUh+Ttun2OLR0RU7vk9wYvQPc8LpqpjqUQROMNzVQ9fO6im/Em0oTVNtaX+h5QU
+493MCCyhkspajU8sTULA9f2l6Et7e03JO1K4lIc7hDDYOvlqwLZJ0+71OBjRnYPT
+9KRmq6fizfrvvpmyBIQKZkTeCWO/9IQahMgnvpSDWXvVtjQPqgJg8vsIWHG+yC6W
+RdXRo8GegNPrmc3wWV8mFDQ09j0ordRODtmnbl4ltiR7GKqPOkVck/hVTGZAm4KF
+uD31pj4Nn3CPhxPbjMw9LsAHLqC+N1g6B2mog9uHLZxB1A1i3h8mKqz6YuzIrRj1
+QLn0CFtToNBm2vY=
+-----END CERTIFICATE-----`)
+
+// TestRetry sets up a test server. The first request should return a
+// Retry-After of 120 seconds with a 202 status code. The second
+// request should return a certificate.
+func TestRetry(t *testing.T) {
+	cli, err := NewClient(testURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	block, _ := pem.Decode(pemCert)
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Parsing pem certificate for test failed. Error: %s", err)
+	}
+
+	delay := true
+	mux.HandleFunc("/acme/cert/asdfouadfs", func(w http.ResponseWriter, r *http.Request) {
+		if delay {
+			w.Header().Set("Retry-After", "120")
+			w.WriteHeader(http.StatusAccepted)
+
+			delay = false
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/pkix-cert")
+		w.WriteHeader(http.StatusOK)
+		w.Write(x509Cert.Raw)
+	})
+
+	certResp := &CertificateResponse{
+		URI:        server.URL + "/acme/cert/asdfouadfs",
+		RetryAfter: 10,
+	}
+
+	cli.Retry(certResp)
+	if certResp.IsAvailable() {
+		t.Error("Expected first call to Retry would not return a certificate")
+	}
+
+	if certResp.RetryAfter != 120 {
+		t.Errorf("Expected RetryAfter of %d, given  %d", 120, certResp.RetryAfter)
+	}
+
+	cli.Retry(certResp)
+	if !certResp.IsAvailable() {
+		t.Error("Expected second call to retry would return a certificate")
+	}
+
+	if !reflect.DeepEqual(certResp.Certificate.Raw, x509Cert.Raw) {
+		t.Error("Expected certificate returned from Retry to be the same")
+	}
+
+	if certResp.RetryAfter != 0 {
+		t.Errorf("Expected RetryAfter to equal %d, given %d", 0, certResp.RetryAfter)
+	}
+}


### PR DESCRIPTION
This is a PR for the conversation started in issue #11 and supersedes #13.

Details:
- `NewCertificate` now returns `CertificateResponse` struct
- `NewCertificate` now supports asynchronous certificates (Not yet in Boulder, but based on spec)
- If `NewCertificate` call results in a synchronous certificate, `CertificateResponse.Certificate` is populated with `*x509.Certificate`. `URI` and `StableURI` are both set. The issuer url is set based on the rel="up" Link header. (see below for more details
- If `NewCertificate` call results in an empty response body, `CertificateResponse` is populated with `RetryAfter` and `URI`.
- `RenewCertificate` method
- `RevokeCertificate` method
- `Retry` method takes a `CertificateResponse` and will handle implementation details to retry the call to `CertificateResponse.URI`. User triggers it based on number of seconds passed in `CertificateResponse.RetryAfter`. Behavior here is the same as `NewCertificate` depending on if the certificate is available or requires another try.
- `Bundle` takes a `CertificateResponse` and allows for bundling the certificate in `CertificateResponse` with the cross-signed Issuer. This is a convenience method and puts the burden on the user to call, but the implementation details are covered in the library.
