### PR TITLE
Added DNS Challenge support and travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.5.3
 script:
   - go test -race -v -bench=.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: go
+go:
+  - 1.5
+script:
+  - go test -race -v -bench=.
+notifications:
+  email: false
+services:
+  - rabbitmq
+addons:
+  apt:
+    packages:
+      - lsb-release
+      - python-dev
+      - python-virtualenv
+      - gcc
+      - libaugeas0
+      - libssl-dev
+      - libffi-dev
+      - ca-certificates
+      - rsyslog
+  mariadb: "10.0"
+  hosts:
+    - example.org
+    - example
+before_install:
+  - git clone --depth=1 https://github.com/letsencrypt/boulder.git $HOME/gopath/src/github.com/letsencrypt/boulder
+before_script:
+  - |
+    # make required changes to boulder rules and start boulder
+    # boulder uses GOPATH to install goose so set that to a single value
+    set -e
+    export ORIGGOPATH=$GOPATH
+    export GOPATH=$HOME/gopath
+    cd $GOPATH/src/github.com/letsencrypt/boulder
+    sed -i '/example.org\|localhost/d' cmd/policy-loader/base-rules.json
+    ./test/setup.sh
+    make
+    ./start.py &
+    BOUDLER_PID=$!
+    export GOPATH=$ORIGGOPATH
+    cd $TRAVIS_BUILD_DIR
+after_script:
+  - kill $BOUDLER_PID

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/ericchiang/letsencrypt",
-	"GoVersion": "go1.5.1",
+	"GoVersion": "go1.5.3",
 	"Deps": [
 		{
 			"ImportPath": "github.com/square/go-jose",

--- a/acme.go
+++ b/acme.go
@@ -430,6 +430,9 @@ func (c *Client) signObject(accountKey interface{}, v interface{}) (string, erro
 	default:
 		err = errors.New("acme: unsupported private key type")
 	}
+	if err != nil {
+		return "", err
+	}
 	data, err := json.Marshal(v)
 	if err != nil {
 		return "", err

--- a/acme_test.go
+++ b/acme_test.go
@@ -359,8 +359,12 @@ func TestParseLinks(t *testing.T) {
 
 func requiresEtcHostsEdits(t *testing.T) {
 	addrs, err := net.LookupHost(testDomain)
-	if err != nil || len(addrs) != 1 || addrs[0] != "127.0.0.1" {
-		t.Skip("/etc/hosts file not properly configured, skipping test. see README for required edits")
+	if err != nil || len(addrs) == 0 || (addrs[0] != "127.0.0.1" && addrs[0] != "::1") {
+		addr := "NXDOMAIN"
+		if len(addrs) > 0 {
+			addr = addrs[0]
+		}
+		t.Skipf("/etc/hosts file not properly configured, skipping test. see README for required edits. %s resolved to %s", testDomain, addr)
 	}
 	return
 }


### PR DESCRIPTION
I added a `.travis.yml` so PRs and master can be built in Travis CI. It was pretty complicated since it has to build and start boulder but after a lot of trial and error I got it working. I couldn't test the final push since the import paths are wrong (`github.com/ericchiang/letsencrypt` vs `github.com/levenlabs/letsencrypt`) but if you turn on Travis CI support we can make sure this PR passes.

I also added DNS challenge support. This required that I included `github.com/miekg/dns` package in godeps so that breaks the diff :disappointed: so I moved that out into a separate commit so you can review the travis and dns commits separately.

I also added:

```
if chal.Type == ChallengeDNS {
    // unauthorized is the TXT value is wrong or not found
    // connection if NXDOMAIN
    if chal.Error.Typ == "urn:acme:error:unauthorized" || chal.Error.Typ == "urn:acme:error:connection" {
        time.Sleep(pollInterval)
        continue
    }
}
```

to the `ChallengeReady` loop since if you're using DNS, the old value or the non-existent value might be cached, so it will continue looping as long as the error is one of those. Let me know what you think.

Fixes #2 
