### PR TITLE
Allow passing http.RoundTripper to Client

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -123,6 +123,12 @@ func (c *Client) Terms() string {
 // NewClient creates a client of a ACME server by querying the server's
 // resource directory and attempting to resolve the URL of the terms of service.
 func NewClient(directoryURL string) (*Client, error) {
+	return NewClientWithTransport(directoryURL, nil)
+}
+
+// NewClientWithTransport creates a client of a ACME server by querying the server's
+// resource directory and attempting to resolve the URL of the terms of service.
+func NewClientWithTransport(directoryURL string, t http.RoundTripper) (*Client, error) {
 	u, err := url.Parse(directoryURL)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse URL %s: %v", directoryURL, err)
@@ -130,8 +136,7 @@ func NewClient(directoryURL string) (*Client, error) {
 	if u.Path == "" {
 		u.Path = boulderDirectoryPath
 	}
-	// TODO: make underlying transport configurable
-	nrt := newNonceRoundTripper(nil)
+	nrt := newNonceRoundTripper(t)
 
 	c := &Client{
 		client:      &http.Client{Transport: nrt},

--- a/acme_test.go
+++ b/acme_test.go
@@ -30,6 +30,13 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientWithTransport(t *testing.T) {
+	rt := http.DefaultTransport
+	if _, err := NewClientWithTransport(testURL, rt); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRegistration(t *testing.T) {
 	tests := []struct {
 		keyType string


### PR DESCRIPTION
Hi.
I'd like to use this package on Google App Engine.
This change made App Engine's urlfetch transport support.
also backwards compatible.

**Normal Environment**

``` go
cli, err := letsencrypt.NewClient(directoryURL)`
```

**GAE Environment**

``` go
t := &urlfetch.Transport{Context: ctx}
cli, err := letsencrypt.NewClientWithTransport(directoryURL, t)
```
