### PR TITLE
fix acme retry condition

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -405,7 +405,7 @@ func handleCertificateResponse(resp *http.Response) (*CertificateResponse, error
 	defer resp.Body.Close()
 
 	// Certificate is not yet available. Gather data and retry later
-	if len(body) == 0 {
+	if resp.StatusCode == http.StatusAccepted {
 		retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing retry-after header: %s", err)


### PR DESCRIPTION
Refer to the ACME protocol on https://tools.ietf.org/id/draft-ietf-acme-acme-01.xml:
> To avoid unnecessary renewals, the CA may choose not to issue a renewed certificate until it receives such a request (if it even allows renewal at all). In such cases, if the CA requires some time to generate the new certificate, the CA MUST return a 202 (Accepted) response, with a Retry-After header field that indicates when the new certificate will be available. The CA MAY include the current (non-renewed) certificate as the body of the response.

When renewing a certificate, the body of the response will be the non-renewed certificate if the certificate is not available. The code should not check if the body of the response is empty. It should check if the status code of the response is 202 based on the ACME protocol.